### PR TITLE
Fix TestRPC Compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ class RpcBlockTracker extends AsyncEventEmitter {
     if (!trackingBlock) throw new Error('RpcBlockTracker - tracking block is missing')
     const nextNumber = incrementHexNumber(trackingBlock.number)
     try {
+      
       const newBlock = await this._fetchBlockByNumber(nextNumber)
       if (newBlock) {
         // set as new tracking block
@@ -91,16 +92,17 @@ class RpcBlockTracker extends AsyncEventEmitter {
       }
 
     } catch (err) {
-
+      
+      // hotfix for https://github.com/ethereumjs/testrpc/issues/290
       if (err.message.includes('index out of range')) {
         // set tracking block as current block
         await this._setCurrentBlock(trackingBlock)
         // setup poll for next block
         this._pollForNextBlock()
-
       } else {
         console.error(err)
       }
+
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,16 @@ class RpcBlockTracker extends AsyncEventEmitter {
       }
 
     } catch (err) {
-      if (err) console.error(err)
+
+      if (err.message.includes('index out of range')) {
+        // set tracking block as current block
+        await this._setCurrentBlock(trackingBlock)
+        // setup poll for next block
+        this._pollForNextBlock()
+
+      } else {
+        console.error(err)
+      }
     }
   }
 


### PR DESCRIPTION
Check network errors for TestRPC's out of range error for when a block is in the future.

This is a temporary band-aid to allow this module to be backwards-compatible with TestRPC for the time being, it would be appropriate to remove this code again in a few months.

Fixes #2